### PR TITLE
Updated documentation for Redactor 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redactor plugin for Craft
 
-This plugin adds a “Redactor” field type to Craft CMS, which provides a rich text editor powered by [Redactor] by Imperavi.
+This plugin adds a “Redactor” field type to Craft CMS, which provides a rich text editor powered by [Redactor](https://imperavi.com/redactor/) by Imperavi.
 
 ## Requirements
 
@@ -10,15 +10,19 @@ This plugin requires Craft CMS 3.0.0-RC15 or later.
 
 To install the plugin, follow these instructions.
 
-1. Open your terminal and go to your Craft project:
+1.  Open your terminal and go to your Craft project:
 
-        cd /path/to/project
+    ```bash
+    cd /path/to/project
+    ```
 
-2. Then tell Composer to load the plugin:
+2.  Then tell Composer to load the plugin:
 
-        composer require craftcms/redactor
+    ```bash
+    composer require craftcms/redactor
+    ```
 
-3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Redactor.
+3.  In the Control Panel, go to Settings → Plugins and click the “Install” button for Redactor.
 
 ## Configuration
 
@@ -26,30 +30,25 @@ To install the plugin, follow these instructions.
 
 You can create custom Redactor configs that will be available to your Redactor fields. They should be created as JSON files in your `config/redactor/` folder.
 
-For example, if you created a `config/redactor/Standard.json` file with the following content: 
+For example, if you created a `config/redactor/Standard.json` file with the following content:
 
 ```json
 {
-    "buttons": ["format", "bold", "italic", "lists", "link", "file", "horizontalrule"],
-    "plugins": ["fullscreen"]
+  "buttons": ["html", "format", "bold", "italic", "lists", "link", "file"],
+  "plugins": ["fullscreen"]
 }
 ```
 
 …then a “Standard” option would become available within the “Redactor Config” setting on your Redactor field’s settings.
 
-See the [Redactor documentation] for a list of available config options.
+See the [Redactor documentation](https://imperavi.com/redactor/docs/settings/) for a list of available config options and buttons.
 
 ### HTML Purifier Configs
 
 You can create custom HTML Purifier configs that will be available to your Redactor fields. They should be created as JSON files in your `config/htmlpurifier/` folder.
 
-See the [HTML Purifier documentation] for a list of available config options. 
+See the [HTML Purifier documentation](http://htmlpurifier.org/live/configdoc/plain.html) for a list of available config options.
 
 ### Redactor JS Plugins
 
-All [1st party Redactor JS plugins] are bundled by default. To enable them, just add the plugin handle to the `plugin` array in your Redactor config.
-
-[Redactor]: https://imperavi.com/redactor/
-[Redactor documentation]: https://imperavi.com/redactor/docs/settings/
-[HTML Purifier documentation]: http://htmlpurifier.org/live/configdoc/plain.html
-[1st party Redactor JS plugins]: https://imperavi.com/redactor/plugins/
+All [1st party Redactor JS plugins](https://imperavi.com/redactor/plugins/) are bundled by default. To enable them, just add the plugin handle to the `plugin` array in your Redactor config.


### PR DESCRIPTION
I’ve updated `README.md`:

- The `source` plugin is no longer a plugin, you need to add a `html` button (Redactor 3)
- The `horizontalrule` button is no longer available (Redactor 3?)
- I’ve improved formatting, too. :)

The new config example should include all frequently used buttons, so you don’t need to head over to the Redactor documentation in most cases. It’s always easier to delete unwanted buttons.

See #42 and #40 