### PR TITLE
Added an option for links to not allow linking to entries

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -258,7 +258,7 @@ class Field extends \craft\base\Field
 
         $settings = [
             'id' => $view->namespaceInputId($id),
-            'linkOptions' => $this->_getLinkOptions($element, $redactorConfig),
+            'linkOptions' => $this->_getLinkOptions($element),
             'volumes' => $this->_getVolumeKeys(),
             'transforms' => $this->_getTransforms(),
             'elementSiteId' => $site->id,

--- a/src/Field.php
+++ b/src/Field.php
@@ -258,7 +258,7 @@ class Field extends \craft\base\Field
 
         $settings = [
             'id' => $view->namespaceInputId($id),
-            'linkOptions' => $this->_getLinkOptions($element),
+            'linkOptions' => $this->_getLinkOptions($element, $redactorConfig),
             'volumes' => $this->_getVolumeKeys(),
             'transforms' => $this->_getTransforms(),
             'elementSiteId' => $site->id,
@@ -458,12 +458,16 @@ class Field extends \craft\base\Field
      */
     private function _getLinkOptions(Element $element = null): array
     {
+        $redactorConfig = $this->_getRedactorConfig();
+
         $linkOptions = [];
 
         $sectionSources = $this->_getSectionSources($element);
         $categorySources = $this->_getCategorySources($element);
 
-        if (!empty($sectionSources)) {
+        $linkToEntry = array_key_exists('linkToEntry', $redactorConfig) ? $redactorConfig['linkToEntry'] : true;
+
+        if ($linkToEntry && !empty($sectionSources)) {
             $linkOptions[] = [
                 'optionTitle' => Craft::t('redactor', 'Link to an entry'),
                 'elementType' => Entry::class,


### PR DESCRIPTION
Added an option 'linkToEntry' to toggle if linking allows selecting entries.  
By default it is true and doesn't change anything, but if set to false, it will not show the option to select entries when linking.