### PR TITLE
Fix cross-site ref parsing

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -274,7 +274,7 @@ class Field extends \craft\base\Field
         }
 
         // Prevent everyone from having to use the |raw filter when outputting RTE content
-        return new FieldData($value);
+        return new FieldData($value, $element);
     }
 
     /**

--- a/src/FieldData.php
+++ b/src/FieldData.php
@@ -8,6 +8,7 @@
 namespace craft\redactor;
 
 use Craft;
+use craft\base\ElementInterface;
 
 /**
  * Stores the data for Redactor fields.
@@ -38,13 +39,13 @@ class FieldData extends \Twig_Markup
      *
      * @param string $content
      */
-    public function __construct(string $content)
+    public function __construct(string $content, ElementInterface $element = null)
     {
         // Save the raw content in case we need it later
         $this->_rawContent = $content;
 
         // Parse the ref tags
-        $content = Craft::$app->getElements()->parseRefs($content);
+        $content = Craft::$app->getElements()->parseRefs($content, $element->siteId ?? null);
 
         parent::__construct($content, Craft::$app->charset);
     }


### PR DESCRIPTION
Fixes #92.

There are still issues due to the fact that refs are not site-specific, despite the site selector showing: #53 

However, this at least will prevent broken ref tags when requested cross-site.