### PR TITLE
Split "cleanupHtml" setting into 3 settings

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -13,7 +13,6 @@ use craft\base\ElementInterface;
 use craft\base\Volume;
 use craft\elements\Category;
 use craft\elements\Entry;
-use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craft\helpers\FileHelper;
 use craft\helpers\Html;

--- a/src/Field.php
+++ b/src/Field.php
@@ -193,11 +193,6 @@ class Field extends \craft\base\Field
     public $purifierConfig;
 
     /**
-     * @deprecated
-     */
-    public $cleanupHtml = true;
-
-    /**
      * @var bool Whether disallowed inline styles should be removed on save
      */
     public $removeInlineStyles = true;
@@ -234,16 +229,6 @@ class Field extends \craft\base\Field
 
     // Public Methods
     // =========================================================================
-
-    /**
-     * @inheritdoc
-     */
-    public function settingsAttributes(): array
-    {
-        $attributes = parent::settingsAttributes();
-        ArrayHelper::removeValue($attributes, 'cleanupHtml');
-        return $attributes;
-    }
 
     /**
      * @inheritdoc

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,7 +21,7 @@ class Plugin extends \craft\base\Plugin
     /**
      * @inheritdoc
      */
-    public $schemaVersion = '2.2.2';
+    public $schemaVersion = '2.3.0';
 
     // Public Methods
     // =========================================================================

--- a/src/migrations/m190225_003922_split_cleanup_html_settings.php
+++ b/src/migrations/m190225_003922_split_cleanup_html_settings.php
@@ -4,6 +4,7 @@ namespace craft\redactor\migrations;
 
 use Craft;
 use craft\db\Migration;
+use craft\db\Query;
 use craft\helpers\Json;
 use craft\services\Fields;
 use craft\services\Matrix;
@@ -28,36 +29,87 @@ class m190225_003922_split_cleanup_html_settings extends Migration
         }
 
         $projectConfig->muteEvents = true;
+        $fieldsToMigrate = [];
 
+        // Migrate regular fields
         $fields = $projectConfig->get(Fields::CONFIG_FIELDS_KEY) ?? [];
-        foreach ($fields as $uid => &$field) {
-            if ($field['type'] === Field::class && isset($field['settings']) && is_array($field['settings'])) {
-                $cleanupHtml = $field['settings']['cleanupHtml'];
-                unset($field['settings']['cleanupHtml']);
-                $field['settings']['removeInlineStyles'] = $cleanupHtml;
-                $field['settings']['removeEmptyTags'] = $cleanupHtml;
-                $field['settings']['removeNbsp'] = $cleanupHtml;
-                $this->update('{{%fields}}', [
-                    'settings' => Json::encode($field['settings']),
-                ], ['uid' => $uid]);
-                $projectConfig->set(Fields::CONFIG_FIELDS_KEY . '.' . $uid, $field);
+        foreach ($fields as $fieldUid => $field) {
+            if (isset($field['type']) && $field['type'] === Field::class) {
+                $fieldsToMigrate[$fieldUid] = [
+                    'configPath' => Fields::CONFIG_FIELDS_KEY . '.' . $fieldUid,
+                    'config' => $field,
+                ];
             }
         }
 
+        // Migrate fields found in Matrix blocks
         $matrixBlockTypes = $projectConfig->get(Matrix::CONFIG_BLOCKTYPE_KEY) ?? [];
-        foreach ($matrixBlockTypes as $matrixBlockTypeUid => &$matrixBlockType) {
-            $fields = $projectConfig->get(Matrix::CONFIG_BLOCKTYPE_KEY . '.' . $matrixBlockTypeUid . '.fields') ?? [];
-            foreach ($fields as $uid => &$field) {
-                if ($field['type'] === Field::class && isset($field['settings']) && is_array($field['settings'])) {
-                    $cleanupHtml = $field['settings']['cleanupHtml'];
-                    unset($field['settings']['cleanupHtml']);
-                    $field['settings']['removeInlineStyles'] = $cleanupHtml;
-                    $field['settings']['removeEmptyTags'] = $cleanupHtml;
-                    $field['settings']['removeNbsp'] = $cleanupHtml;
-                    $this->update('{{%fields}}', [
-                        'settings' => Json::encode($field['settings']),
-                    ], ['uid' => $uid]);
-                    $projectConfig->set(Matrix::CONFIG_BLOCKTYPE_KEY . '.' . $matrixBlockTypeUid . '.fields.' . $uid, $field);
+        foreach ($matrixBlockTypes as $matrixBlockTypeUid => $matrixBlockType) {
+            $fields = $matrixBlockType['fields'] ?? [];
+            foreach ($fields as $fieldUid => $field) {
+                if (isset($field['type']) && $field['type'] === Field::class) {
+                    $fieldsToMigrate[$fieldUid] = [
+                        'configPath' => Matrix::CONFIG_BLOCKTYPE_KEY . '.' . $matrixBlockTypeUid . '.fields.' . $fieldUid,
+                        'config' => $field,
+                    ];
+                }
+            }
+        }
+
+        // Migrate fields found in Super Table
+        $superTableBlockTypes = $projectConfig->get('superTableBlockTypes') ?? [];
+        if ($superTableBlockTypes) {
+            foreach ($superTableBlockTypes as $superTableBlockTypeUid => $superTableBlockType) {
+                $fields = $superTableBlockType['fields'] ?? [];
+                foreach ($fields as $fieldUid => $field) {
+                    if (isset($field['type']) && $field['type'] === Field::class) {
+                        $fieldsToMigrate[$fieldUid] = [
+                            'configPath' => 'superTableBlockTypes.' . $superTableBlockTypeUid . '.fields.' . $fieldUid,
+                            'config' => $field,
+                        ];
+                    }
+                }
+            }
+        }
+        else {
+            // If Super Table is not yet installed but we can find fields that need updating in the DB
+            $superTableRedactorFields = (new Query())
+                ->select(['uid', 'settings'])
+                ->from(['{{%fields}}'])
+                ->where([
+                    'and',
+                    ['like', 'context', 'superTableBlockType'],
+                    ['in', 'type', ['Redactor']],
+                ])
+                ->all();
+            foreach ($superTableRedactorFields as $superTableRedactorField) {
+                $fieldsToMigrate[$superTableRedactorField['uid']] = [
+                    'configPath' => false,
+                    'config' => [
+                        'settings' => Json::decode($superTableRedactorField['settings']),
+                    ],
+                ];
+            }
+        }
+    
+        // Go ahead and migrate them
+        foreach ($fieldsToMigrate as $fieldUid => $field)
+        {
+            $fieldConfigPath = $field['configPath'];
+            $fieldConfig = $field['config'];
+            if (isset($fieldConfig['settings']) && is_array($fieldConfig['settings'])) {
+                $fieldSettings = $fieldConfig['settings'];
+                $cleanupHtml = $fieldSettings['cleanupHtml'];
+                unset($fieldSettings['cleanupHtml']);
+                $fieldSettings['removeInlineStyles'] = $cleanupHtml;
+                $fieldSettings['removeEmptyTags'] = $cleanupHtml;
+                $fieldSettings['removeNbsp'] = $cleanupHtml;
+                $this->update('{{%fields}}', [
+                    'settings' => Json::encode($fieldSettings),
+                ], ['uid' => $fieldUid]);
+                if ($fieldConfigPath) {
+                    $fieldConfig['settings'] = $fieldSettings;
+                    $projectConfig->set($fieldConfigPath, $fieldConfig);
                 }
             }
         }

--- a/src/migrations/m190225_003922_split_cleanup_html_settings.php
+++ b/src/migrations/m190225_003922_split_cleanup_html_settings.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace craft\redactor\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
+use craft\helpers\Json;
+use craft\helpers\ArrayHelper;
+
+/**
+ * m190225_003922_split_cleanup_html_settings migration.
+ */
+class m190225_003922_split_cleanup_html_settings extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $fields = (new Query())
+            ->select(['id', 'settings'])
+            ->from([Table::FIELDS])
+            ->where(['type' => 'craft\\redactor\\Field'])
+            ->all($this->db);
+
+        $fieldsService = Craft::$app->getFields();
+
+        foreach ($fields as $field) {
+            $settings = Json::decode($field['settings']);
+            if (is_array($settings) && array_key_exists('cleanupHtml', $settings)) {
+                $cleanupHtml = ArrayHelper::remove($settings, 'cleanupHtml');
+                $settings['removeInlineStyles'] = $cleanupHtml;
+                $settings['removeEmptyTags'] = $cleanupHtml;
+                $settings['removeNbsp'] = $cleanupHtml;
+                $this->update(Table::FIELDS, ['settings' => Json::encode($settings)], ['id' => $field['id']]);
+                $fieldsService->saveField($fieldsService->getFieldById($field['id']));
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m190225_003922_split_cleanup_html_settings cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/migrations/m190225_003922_split_cleanup_html_settings.php
+++ b/src/migrations/m190225_003922_split_cleanup_html_settings.php
@@ -4,10 +4,10 @@ namespace craft\redactor\migrations;
 
 use Craft;
 use craft\db\Migration;
-use craft\db\Query;
-use craft\db\Table;
 use craft\helpers\Json;
-use craft\helpers\ArrayHelper;
+use craft\services\Fields;
+use craft\services\Matrix;
+use craft\redactor\Field;
 
 /**
  * m190225_003922_split_cleanup_html_settings migration.
@@ -19,25 +19,50 @@ class m190225_003922_split_cleanup_html_settings extends Migration
      */
     public function safeUp()
     {
-        $fields = (new Query())
-            ->select(['id', 'settings'])
-            ->from([Table::FIELDS])
-            ->where(['type' => 'craft\\redactor\\Field'])
-            ->all($this->db);
+        $projectConfig = Craft::$app->getProjectConfig();
 
-        $fieldsService = Craft::$app->getFields();
+        // Don't make the same config changes twice
+        $schemaVersion = $projectConfig->get('plugins.redactor.schemaVersion', true);
+        if (version_compare($schemaVersion, '2.3.0', '>=')) {
+            return true;
+        }
 
-        foreach ($fields as $field) {
-            $settings = Json::decode($field['settings']);
-            if (is_array($settings) && array_key_exists('cleanupHtml', $settings)) {
-                $cleanupHtml = ArrayHelper::remove($settings, 'cleanupHtml');
-                $settings['removeInlineStyles'] = $cleanupHtml;
-                $settings['removeEmptyTags'] = $cleanupHtml;
-                $settings['removeNbsp'] = $cleanupHtml;
-                $this->update(Table::FIELDS, ['settings' => Json::encode($settings)], ['id' => $field['id']]);
-                $fieldsService->saveField($fieldsService->getFieldById($field['id']));
+        $projectConfig->muteEvents = true;
+
+        $fields = $projectConfig->get(Fields::CONFIG_FIELDS_KEY) ?? [];
+        foreach ($fields as $uid => &$field) {
+            if ($field['type'] === Field::class && isset($field['settings']) && is_array($field['settings'])) {
+                $cleanupHtml = $field['settings']['cleanupHtml'];
+                unset($field['settings']['cleanupHtml']);
+                $field['settings']['removeInlineStyles'] = $cleanupHtml;
+                $field['settings']['removeEmptyTags'] = $cleanupHtml;
+                $field['settings']['removeNbsp'] = $cleanupHtml;
+                $this->update('{{%fields}}', [
+                    'settings' => Json::encode($field['settings']),
+                ], ['uid' => $uid]);
+                $projectConfig->set(Fields::CONFIG_FIELDS_KEY . '.' . $uid, $field);
             }
         }
+
+        $matrixBlockTypes = $projectConfig->get(Matrix::CONFIG_BLOCKTYPE_KEY) ?? [];
+        foreach ($matrixBlockTypes as $matrixBlockTypeUid => &$matrixBlockType) {
+            $fields = $projectConfig->get(Matrix::CONFIG_BLOCKTYPE_KEY . '.' . $matrixBlockTypeUid . '.fields') ?? [];
+            foreach ($fields as $uid => &$field) {
+                if ($field['type'] === Field::class && isset($field['settings']) && is_array($field['settings'])) {
+                    $cleanupHtml = $field['settings']['cleanupHtml'];
+                    unset($field['settings']['cleanupHtml']);
+                    $field['settings']['removeInlineStyles'] = $cleanupHtml;
+                    $field['settings']['removeEmptyTags'] = $cleanupHtml;
+                    $field['settings']['removeNbsp'] = $cleanupHtml;
+                    $this->update('{{%fields}}', [
+                        'settings' => Json::encode($field['settings']),
+                    ], ['uid' => $uid]);
+                    $projectConfig->set(Matrix::CONFIG_BLOCKTYPE_KEY . '.' . $matrixBlockTypeUid . '.fields.' . $uid, $field);
+                }
+            }
+        }
+
+        $projectConfig->muteEvents = false;
     }
 
     /**

--- a/src/templates/_field_settings.html
+++ b/src/templates/_field_settings.html
@@ -38,16 +38,44 @@
 <hr>
 <a class="fieldtoggle" data-target="advanced">{{ "Advanced"|t('redactor') }}</a>
 <div id="advanced" class="hidden">
-    {{ forms.checkboxField({
-        label: "Clean up HTML?"|t('redactor'),
-        instructions: "Removes <code>&lt;span&gt;</code>’s, empty tags, non-breaking whitespace and most <code>style</code> attributes on save."|t('redactor'),
-        id: 'cleanupHtml',
-        name: 'cleanupHtml',
-        checked: field.cleanupHtml
-    }) }}
+    <div class="field">
+        <div class="heading">
+            <label>{{ "Clean up HTML"|t('redactor') }}</label>
+            <div class="instructions">
+                {{ "The cleanup actions that should be executed on save."|t('redactor') }}
+            </div>
+        </div>
+
+        <div>
+            {{ forms.checkbox({
+                label: "Remove inline styles"|t('redactor'),
+                id: 'removeInlineStyles',
+                name: 'removeInlineStyles',
+                checked: field.removeInlineStyles
+            }) }}
+        </div>
+
+        <div>
+            {{ forms.checkbox({
+                label: "Remove empty tags"|t('redactor'),
+                id: 'removeEmptyTags',
+                name: 'removeEmptyTags',
+                checked: field.removeEmptyTags
+            }) }}
+        </div>
+
+        <div>
+            {{ forms.checkbox({
+                label: "Replace non-breaking spaces with regular spaces"|t('redactor'),
+                id: 'removeNbsp',
+                name: 'removeNbsp',
+                checked: field.removeNbsp
+            }) }}
+        </div>
+    </div>
 
     {{ forms.checkboxField({
-        label: "Purify HTML?"|t('redactor'),
+        label: "Purify HTML"|t('redactor'),
         instructions: 'Removes any potentially-malicious code on save, by running the submitted data through <a href="http://htmlpurifier.org/" rel="noopener" target="_blank">HTML Purifier</a>.'|t('redactor'),
         warning: 'Disable this at your own risk!'|t('redactor'),
         id: 'purifyHtml',


### PR DESCRIPTION
This is my proposal to implement #72 which I would really need for the reason described in that issue.

I wasn't sure how to handle the deprecation of `cleanupHtml`; if I simply removed the property from the Field class, I got an `yii\base\UnknownPropertyException` at every request, so the migration didn't have a chance to run. But if I simply kept it there, it was re-added to the project config and the database every time a Redactor field was saved. I ended up removing it from the array returned by `settingsAttributes()`. It seems to work, but I couldn't find any precedent in the Craft codebase, so let me know if there's a better way to handle it.

I'm also not sure if it's a good idea to call `Craft::$app->getFields()->saveField()` in the migration. I'm doing it so the project config is updated if it's used (so any reference to `cleanupHtml` is removed from it), but again, maybe there's another way to handle that.

Thank you for your consideration! :)