### PR TITLE
Dropdown format bar for h6 tag match redactor field

### DIFF
--- a/src/assets/field/dist/css/RedactorInput.scss
+++ b/src/assets/field/dist/css/RedactorInput.scss
@@ -55,6 +55,7 @@ body {
     .redactor-dropdown-item-h6 {
       font-size: 13.6px;
       color: $mediumTextColor;
+      text-transform: none;
     }
 
     .redactor-dropdown-item-pre {


### PR DESCRIPTION
Craft defines CSS for the `h6` tag in the redactor field to text-transform: none. It doesn't make this same change to the `h6` selector in the format bar. This makes the `h6` in the dropdown bar UPPERCASE, inherited from the Redactor default.

The `h6` should be the same visually in the dropdown bar and the text entry area for Redactor in the control panel.