### PR TITLE
Sort the list of Redactor Config files

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -948,6 +948,8 @@ class Field extends \craft\base\Field
                 }
             }
         }
+        
+        ksort($options);
 
         return $options;
     }


### PR DESCRIPTION
Sorts the list of Redactor Config files alphabetically, maintaining key association

### Description

Currently the list of Redactor Config files shown in the dropdown is ordered however they are stored in the filesystem (returned from `FileHelper::findFiles()` which uses `readdir`). This sorts this list alphabetically by key (filename) while maintaining key association.

### Related issues

No related issues that I could find.