### PR TITLE
Fixes heading level in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for Redactor for Craft CMS
 
-### 2.10.1 - 2022-02-16
+## 2.10.1 - 2022-02-16
 
 ### Changed
 - Improved HTML sanitizing on input.


### PR DESCRIPTION
### Description

The changelog details aren’t coming through for the v2.10.1 release of Redactor:
 
<img width="994" alt="Screen Shot 2022-02-16 at 8 47 51 AM" src="https://user-images.githubusercontent.com/1581276/154315326-c216940f-6e7f-4e76-bb35-38e3906a2e14.png">

I’ve changed the Markdown heading from an h3 to an h2, which I’m guessing is the issue.
