### PR TITLE
fix-410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Fixed
+- Fixed a bug where entry link modals would lose context on multi-site. ([#410](https://github.com/craftcms/redactor/issues/410))
+
+### Fixed
 - Fixed a bug where non-admin users weren’t able to insert images or link to assets. ([#409](https://github.com/craftcms/redactor/issues/409)) 
 
 ## 3.0.0 - 2022-05-03

--- a/src/Field.php
+++ b/src/Field.php
@@ -405,7 +405,7 @@ class Field extends HtmlField
             'volumes' => $this->_getVolumeKeys(),
             'transforms' => $this->_getTransforms(),
             'defaultTransform' => $defaultTransform,
-            'elementSiteId' => $elementSite,
+            'elementSiteId' => $elementSite->id,
             'allSites' => $allSites,
             'redactorConfig' => $redactorConfig,
             'redactorLang' => $redactorLang,


### PR DESCRIPTION
Issue #410 was happening on Craft 3 installs. The fix solves the issue and doesn't change anything on Craft 4 but we might need to cut a 2.10.9 release.

Should also solve #412
