### PR TITLE
[4.x] Fix reference to missing (old) migration

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -23,9 +23,6 @@ class Install extends Migration
             'type' => 'craft\\fields\\RichText',
         ], [], false);
 
-        // Update any Redactor configs
-        Plugin::getInstance()->getMigrator()->migrateUp('m180430_204710_remove_old_plugins');
-
         return true;
     }
 


### PR DESCRIPTION
I get the following error when installing 4.0 for Craft 5 on a new install.

![image](https://github.com/craftcms/redactor/assets/1221575/28b6ca25-4911-436d-8480-f7fdb0c21b3d)

This is because there's a reference to the old, no longer needed migration.