### PR TITLE
Remove `columnType` reference

### DIFF
--- a/src/templates/_field_settings.html
+++ b/src/templates/_field_settings.html
@@ -172,19 +172,4 @@
       value: field.purifierConfig
     }) }}
   </div>
-
-  {% if craft.app.db.isMysql %}
-    {{ forms.selectField({
-      label: "Column Type"|t('redactor'),
-      id: 'column-type',
-      name: 'columnType',
-      instructions: "The type of column this field should get in the database."|t('redactor'),
-      options: [
-        { value: 'text', label: 'text (~64KB)' },
-        { value: 'mediumtext', label: 'mediumtext (~16MB)' },
-      ],
-      value: field.columnType,
-      warning: (field.id ? "Changing this may result in data loss."|t('redactor')),
-    }) }}
-  {% endif %}
 </div>


### PR DESCRIPTION
Correct me if I'm wrong, but this advanced field setting isn't needed anymore, correct? It'll throw an error when viewing the field settings.